### PR TITLE
Check for https in redactor links

### DIFF
--- a/app/assets/javascripts/formstrap.js
+++ b/app/assets/javascripts/formstrap.js
@@ -14462,11 +14462,13 @@ Redactor.add("plugin", "linkstyles", {
       }
     },
     "link.change": function(e) {
-      const link = e.params.element.nodes[0];
+      var link = e.params.element.nodes[0];
+      link = this.addHttps(link);
       this.applyStylingToLink(link);
     },
     "link.add": function(e) {
-      const link = e.params.element.nodes[0];
+      var link = e.params.element.nodes[0];
+      link = this.addHttps(link);
       this.applyStylingToLink(link);
     }
   },
@@ -14489,6 +14491,17 @@ Redactor.add("plugin", "linkstyles", {
         return;
       link.classList.add(className);
     });
+  },
+  addHttps(link) {
+    var url = link.getAttribute("href");
+    if (url.startsWith("http://")) {
+      url = url.replace("http://", "https://");
+    }
+    if (!url.startsWith("https://")) {
+      url = "https://" + url;
+    }
+    link.setAttribute("href", url);
+    return link;
   },
   buildSelect() {
     const select = this.dom("<select>").addClass("rx-form-select");

--- a/app/assets/javascripts/formstrap/vendor/redactor/plugins/linkstyles.js
+++ b/app/assets/javascripts/formstrap/vendor/redactor/plugins/linkstyles.js
@@ -31,11 +31,13 @@ Redactor.add('plugin', 'linkstyles', {
       }
     },
     'link.change': function (e) {
-      const link = e.params.element.nodes[0]
+      var link = e.params.element.nodes[0]
+      link = this.addHttps(link) 
       this.applyStylingToLink(link)
     },
     'link.add': function (e) {
-      const link = e.params.element.nodes[0]
+      var link = e.params.element.nodes[0]
+      link = this.addHttps(link) 
       this.applyStylingToLink(link)
     }
   },
@@ -47,6 +49,7 @@ Redactor.add('plugin', 'linkstyles', {
     const stack = this.app.modal.getStack()
 
     const item = stack.getFormItem('url')
+
     const box = this.dom('<div>').addClass('rx-form-item')
 
     // Add a select
@@ -68,6 +71,21 @@ Redactor.add('plugin', 'linkstyles', {
       if (className.length === 0) return
       link.classList.add(className)
     })
+  },
+  addHttps(link) {
+    var url = link.getAttribute("href")
+
+    if (url.startsWith("http://")) {
+        url = url.replace("http://", "https://")
+    }
+
+    if (!url.startsWith("https://")) {
+
+        url = "https://" + url  
+    }
+
+    link.setAttribute("href", url)
+    return link;
   },
   buildSelect () {
     // Create a select node


### PR DESCRIPTION
The suggested solution does not work (changing the type of the input from text to url). It is possible to change the type but validations does not seem to be running (probably disabled by Redactor).

What is possible is to make a check when the link gets added. 

What we do now is check if the link being submitted has "https://". If not, we add it. Furthermore, if http:// is given we change it to https://. 